### PR TITLE
Fix OpenRouter model fetching for selector

### DIFF
--- a/app/api/models/route.ts
+++ b/app/api/models/route.ts
@@ -1,30 +1,9 @@
 import { NextResponse } from 'next/server';
-import type { ChatModel } from '@/lib/ai/models';
+import { getStaticModels } from '@/lib/ai/models';
 
 export async function GET() {
   try {
-    const response = await fetch('https://openrouter.ai/api/v1/models', {
-      headers: {
-        Authorization: `Bearer ${process.env.OPENROUTER_API_KEY}`,
-      },
-    });
-
-    if (!response.ok) {
-      throw new Error('Failed to fetch models');
-    }
-
-    const data = await response.json();
-    const models: ChatModel[] = data.data
-      .filter(
-        (model: any) =>
-          model.id.includes('chat') || model.id.includes('instruct'),
-      )
-      .map((model: any) => ({
-        id: model.id,
-        name: model.name || model.id.split('/').pop(),
-        description: model.description || 'OpenRouter model',
-      }));
-
+    const models = await getStaticModels();
     return NextResponse.json({ models });
   } catch (error) {
     console.error('Error fetching models:', error);

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -23,41 +23,149 @@ export interface ChatModel {
   description: string;
 }
 
+const CACHE_DURATION_MS = 1000 * 60 * 60; // 1 hour
+
+const FALLBACK_CHAT_MODELS: ChatModel[] = [
+  {
+    id: DEFAULT_CHAT_MODEL,
+    name: 'GPT-4o Mini',
+    description: 'Default fallback model (OpenRouter)',
+  },
+];
+
 let cachedModels: ChatModel[] | null = null;
 let lastFetchTime: number | null = null;
 
-// Fetch and cache models from OpenRouter API
-async function fetchAndCacheModels(): Promise<ChatModel[]> {
-  const now = Date.now();
-  // Cache for 1 hour
-  if (cachedModels && lastFetchTime && now - lastFetchTime < 3600000) {
-    return cachedModels;
+function getModelsEndpoint(): string {
+  const baseURL = process.env.OPENROUTER_BASE_URL || 'https://openrouter.ai/api/v1';
+  return `${baseURL.replace(/\/$/, '')}/models`;
+}
+
+function buildHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = {
+    'HTTP-Referer':
+      process.env.NEXT_PUBLIC_APP_URL || 'https://app.intellisync.com.au',
+    'X-Title': 'IntelliSync Chatbot',
+  };
+
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  return headers;
+}
+
+const SKIP_MODEL_PATTERNS = ['embed', 'embedding', 'rerank', 'moderation'];
+
+async function requestModelsFromOpenRouter(): Promise<ChatModel[]> {
+  if (typeof window !== 'undefined') {
+    return FALLBACK_CHAT_MODELS;
+  }
+
+  const apiKey = process.env.OPENROUTER_API_KEY;
+
+  if (!apiKey) {
+    console.warn('OpenRouter API key is not configured. Using fallback models.');
+    return [];
   }
 
   try {
-    const response = await fetch('https://openrouter.ai/api/v1/models');
+    const response = await fetch(getModelsEndpoint(), {
+      headers: buildHeaders(apiKey),
+    });
+
     if (!response.ok) {
-      throw new Error('Failed to fetch models from OpenRouter API');
+      throw new Error(`Failed to fetch models from OpenRouter API (${response.status})`);
     }
-    const { data } = await response.json();
-    cachedModels = data.map((model: any) => ({
-      id: model.id,
-      name: model.name,
-      description: model.description,
-    }));
-    lastFetchTime = now;
-    return cachedModels || [];
+
+    const payload = (await response.json()) as { data?: unknown };
+
+    if (!payload || !Array.isArray(payload.data)) {
+      console.warn('Unexpected OpenRouter models payload:', payload);
+      return [];
+    }
+
+    return (
+      payload.data
+        .map((raw) => {
+          if (!raw || typeof raw !== 'object') {
+            return null;
+          }
+
+          const {
+            id,
+            name,
+            description,
+          } = raw as {
+            id?: unknown;
+            name?: unknown;
+            description?: unknown;
+          };
+
+          if (typeof id !== 'string') {
+            return null;
+          }
+
+          const lowerId = id.toLowerCase();
+
+          if (SKIP_MODEL_PATTERNS.some((pattern) => lowerId.includes(pattern))) {
+            return null;
+          }
+
+          const resolvedName =
+            typeof name === 'string' && name.trim().length > 0
+              ? name.trim()
+              : id;
+
+          const resolvedDescription =
+            typeof description === 'string' && description.trim().length > 0
+              ? description.trim()
+              : 'OpenRouter model';
+
+          return {
+            id,
+            name: resolvedName,
+            description: resolvedDescription,
+          } satisfies ChatModel;
+        })
+        .filter((model): model is ChatModel => model !== null)
+        .sort((a, b) =>
+          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+        )
+    );
   } catch (error) {
-    console.error('Error fetching or caching models:', error);
-    // Return a default list if fetch fails
-    return [
-      {
-        id: 'openai/gpt-4o-mini',
-        name: 'GPT-4o Mini',
-        description: 'Default fallback model',
-      },
-    ];
+    console.error('Error fetching models from OpenRouter:', error);
+    return [];
   }
+}
+
+// Fetch and cache models from OpenRouter API
+async function fetchAndCacheModels(): Promise<ChatModel[]> {
+  if (typeof window !== 'undefined') {
+    return FALLBACK_CHAT_MODELS;
+  }
+
+  const now = Date.now();
+
+  if (cachedModels && lastFetchTime && now - lastFetchTime < CACHE_DURATION_MS) {
+    return cachedModels;
+  }
+
+  const models = await requestModelsFromOpenRouter();
+
+  if (models.length > 0) {
+    cachedModels = models;
+    lastFetchTime = now;
+    return models;
+  }
+
+  if (cachedModels) {
+    return cachedModels;
+  }
+
+  cachedModels = FALLBACK_CHAT_MODELS;
+  lastFetchTime = now;
+  return FALLBACK_CHAT_MODELS;
 }
 
 export const getStaticModels = async (): Promise<ChatModel[]> => {


### PR DESCRIPTION
## Summary
- add a reusable OpenRouter model fetcher with caching, auth headers, and fallback handling
- return server-fetched models from the `/api/models` endpoint so the selector receives dynamic options

## Testing
- pnpm exec biome lint lib/ai/models.ts app/api/models/route.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc789dcea88328ad7b84decf67922f